### PR TITLE
Fix rspec raise syntax for increment tests

### DIFF
--- a/spec/semantic_range_increment_versions_spec.rb
+++ b/spec/semantic_range_increment_versions_spec.rb
@@ -96,7 +96,7 @@ describe SemanticRange do
         expect(parsed.version).to eq(wanted), "increment(*#{input}) object version updated"
         expect(parsed.raw).to eq(wanted), "increment(*#{input}) object raw field updated"
       elsif parsed
-        expect(SemanticRange.parse(what, id)).to raise_error
+        expect { SemanticRange.parse(what, id) }.to raise_error
       else
         expect(parsed).to eq(nil)
       end


### PR DESCRIPTION
Use a block to catch the error instead so the error can be tested