### PR TITLE
Use the correct variable in the "to" variable when the last item as two numbers

### DIFF
--- a/lib/semantic_range/range.rb
+++ b/lib/semantic_range/range.rb
@@ -265,7 +265,7 @@ module SemanticRange
       elsif isX(tm)
         to = "<#{(tM.to_i + 1)}.0.0"
       elsif isX(tp)
-        to = "<#{tm}.#{(tm.to_i + 1)}.0"
+        to = "<#{tM}.#{(tm.to_i + 1)}.0"
       elsif tpr
         to = "<=#{tM}.#{tm}.#{tp}-#{tpr}"
       else


### PR DESCRIPTION
Fixes the failing spec from #17 