### PR TITLE
Remove rescue from SemanticRange.parse

### DIFF
--- a/lib/semantic_range.rb
+++ b/lib/semantic_range.rb
@@ -237,11 +237,7 @@ module SemanticRange
     rxp = loose ? LOOSE : FULL
     return nil if !rxp.match(version)
 
-    begin
-      Version.new(version, loose)
-    rescue
-      nil
-    end
+    Version.new(version, loose)
   end
 
   def self.increment!(version, release, loose, identifier)


### PR DESCRIPTION
It doesn't seem to have any effect, and if there is an error in the version creation then it would be easier to debug without the rescue