### PR TITLE
Add support for range and comparators comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea

--- a/lib/semantic_range/range.rb
+++ b/lib/semantic_range/range.rb
@@ -279,5 +279,15 @@ module SemanticRange
 
       "#{from} #{to}".strip
     end
+
+    def intersects(range, loose = false, platform = nil)
+      range = Range.new(range, loose, platform)
+
+      @set.any? do |comparators|
+        comparators.all? do |comparator|
+          comparator.satisfies_range(range, loose, platform)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
* Check if two ranges intersect
* Check if one comparator satisfies a range
* Check if two comparators intersect

Fixes #61

Notes:
I had to change the `Comparator` initializer since it was not working as I expected.
For some reason, in:
```ruby
if comp.is_a?(Comparator)
  return comp if comp.loose == loose
  @comp = comp.value
end
```

The `return comp if comp.loose == loose` was not returning a working Comparator object. Since I am not experienced with ruby I still do not know the internals of the initializer. Maybe you can help me understand this.

Still, my change makes this class use the same logic that exists in `Range` and `Version` by replacing the if with `comp = comp.value if comp.is_a?(Comparator)`. Although it works now I am aware it seems redundant. If you have any insights please let me know.