### PR TITLE
gemspec: Reduce size of packaged gem

### DIFF
--- a/semantic_range.gemspec
+++ b/semantic_range.gemspec
@@ -13,9 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://libraries.io/github/librariesio/semantic_range"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files         = Dir["lib/**/*"] + ["README.md", "LICENSE.txt"]
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
This PR attempts to keep the size of the gem down to the useful bits only.

- Include only the `README.md`, the `LICENSE.txt` and the `lib` directory
- Drop the `bindir` and `executables` settings, since this gem ships no executable

I hope that this helps.

---

In case you're curious about more of this pruning activity, here is a repo of a RuboCop extension which looks at issues like this: https://github.com/utkarsh2102/rubocop-packaging