### PR TITLE
Remove unused variables

### DIFF
--- a/lib/semantic_range/range.rb
+++ b/lib/semantic_range/range.rb
@@ -191,7 +191,6 @@ module SemanticRange
         mj = match[2]
         m = match[3]
         p = match[4]
-        pr = match[5]
 
         xM = isX(mj)
         xm = xM || isX(m)
@@ -249,14 +248,11 @@ module SemanticRange
       fM = match[2]
       fm = match[3]
       fp = match[4]
-      fpr = match[5]
-      fb = match[6]
       to = match[7]
       tM = match[8]
       tm = match[9]
       tp = match[10]
       tpr = match[11]
-      tb = match[12]
 
       if isX(fM)
         from = ''


### PR DESCRIPTION
These cause annoying warnings on Rails CI: https://buildkite.com/rails/rails/builds/78314#dae4ea64-0ac4-4d20-81e1-6746095fa542/1119-1125

```
/usr/local/bundle/gems/semantic_range-3.0.0/lib/semantic_range/range.rb:194: warning: assigned but unused variable - pr
/usr/local/bundle/gems/semantic_range-3.0.0/lib/semantic_range/range.rb:252: warning: assigned but unused variable - fpr
/usr/local/bundle/gems/semantic_range-3.0.0/lib/semantic_range/range.rb:253: warning: assigned but unused variable - fb
/usr/local/bundle/gems/semantic_range-3.0.0/lib/semantic_range/range.rb:259: warning: assigned but unused variable - tb
```
